### PR TITLE
Fix water splash issue by reverting commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# This is a fork of JShorthouse's Zombie Survival gamemode!
-I made this fork for my very own server so I can share the fixes I made and additions for other server hosts and for JShorthouse's fork of Zombie Survival.
+# Zombie Survival Fixes
+
+Repository containing fixes and enhancements to the Zombie Survival gamemode due to them no longer being publicly released or actively merged with the main repo.
+
+New features will not be included in this repo, unless they are needed as part of a fix or for balancing reasons. (No new weapons, zombie classes etc.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-# Zombie Survival Fixes
-
-Repository containing fixes and enhancements to the Zombie Survival gamemode due to them no longer being publicly released or actively merged with the main repo.
-
-New features will not be included in this repo, unless they are needed as part of a fix or for balancing reasons. (No new weapons, zombie classes etc.)
+# This is a fork of JShorthouse's Zombie Survival gamemode!
+I made this fork for my very own server so I can share the fixes I made and additions for other server hosts and for JShorthouse's fork of Zombie Survival.
 
 ## Contributing
 

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/shared.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/shared.lua
@@ -150,9 +150,9 @@ function SWEP:MeleeSwing()
 
 	local filter = owner:GetMeleeFilter()
 
-	--owner:LagCompensation(true)
+	owner:LagCompensation(true)
 
-	local tr = owner:ClipHullMeleeTrace(self.MeleeRange, self.MeleeSize, filter)
+	local tr = owner:MeleeTrace(self.MeleeRange, self.MeleeSize, filter)
 	if tr.Hit then
 		local damagemultiplier = (owner.BuffMuscular and owner:Team()==TEAM_HUMAN) and 1.2 or 1
 		local damage = self.MeleeDamage * damagemultiplier
@@ -179,7 +179,7 @@ function SWEP:MeleeSwing()
 		end
 
 		if self.OnMeleeHit and self:OnMeleeHit(hitent, hitflesh, tr) then
-			--owner:LagCompensation(false)
+			owner:LagCompensation(false)
 			return
 		end
 
@@ -247,7 +247,7 @@ function SWEP:MeleeSwing()
 		if self.PostOnMeleeMiss then self:PostOnMeleeMiss(tr) end
 	end
 
-	--owner:LagCompensation(false)
+	owner:LagCompensation(false)
 end
 
 function SWEP:StopSwinging()
@@ -317,7 +317,7 @@ function SWEP:SetWeaponHoldType( t )
 	end
 
 	-- these two aren't defined in ACTs for whatever reason
-	if t == "knife" || t == "melee2" then
+	if t == "knife" or t == "melee2" then
 		self.ActivityTranslate [ ACT_MP_CROUCH_IDLE ] = nil
 	end
 end


### PR DESCRIPTION
No clue why but reverting the commit when the shared.lua was changed by JetBoom fixes the infinite water splash issue with melee weapons.